### PR TITLE
Fix Windows compilation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@ SRC_PATH ?= src
 BIN_PATH ?= bin
 JGRAPHT_CLASS_PATH ?= jgrapht/jgrapht-core/src/main/java
 EXTERNAL_JARS_PATHS ?= lib/gson-2.8.2.jar
-FLAGS ?= -Xlint -cp "$(SRC_PATH):$(JGRAPHT_CLASS_PATH):$(EXTERNAL_JARS_PATHS)" -d $(BIN_PATH)
+ifeq ($(OS),Windows_NT)
+	COMPILE_CLASS_PATH ?= "$(SRC_PATH);$(JGRAPHT_CLASS_PATH);$(EXTERNAL_JARS_PATHS)"
+else
+	COMPILE_CLASS_PATH ?= "$(SRC_PATH):$(JGRAPHT_CLASS_PATH):$(EXTERNAL_JARS_PATHS)"
+endif
+FLAGS ?= -Xlint -cp $(COMPILE_CLASS_PATH) -d $(BIN_PATH)
 JAR_NAME ?= RegexStaticAnalysis.jar
 
 

--- a/src/analysis/ExploitStringBuilder.java
+++ b/src/analysis/ExploitStringBuilder.java
@@ -155,8 +155,8 @@ public class ExploitStringBuilder implements ExploitStringBuilderInterface<EdaAn
 					String currentString = "" + currentChar;
 					if (currentChar == '[') {
 						currentString = "\\" + currentChar;
-					} else if (currentChar == 'ε') {
-						currentString = "[ε]";
+					} else if (currentChar == '\u03b5') {
+						currentString = "[\u03b5]";
 					}
 					if (!wholeAlphabet.matches(currentString)) {						
 						return "" + ((char) i);


### PR DESCRIPTION
First of all, thanks for making and maintaining this. This is a very interesting, fun, and useful tool.

This PR fixes two issues that I ran into trying to build this on Windows:
- The Makefile uses the Unix-friendly classpath delimiters by default. This PR adds a condition for Windows compilation.
- `javac` doesn't appear to use UTF-8 encoding by default on my system. This causes the following errors during compilation:
    ```
    src\analysis\ExploitStringBuilder.java:158: error: unclosed character literal
                                            } else if (currentChar == '╬╡') {
                                                                      ^
    src\analysis\ExploitStringBuilder.java:158: error: unclosed character literal
                                            } else if (currentChar == '╬╡') {
                                                                         ^
    src\analysis\ExploitStringBuilder.java:158: error: not a statement
                                            } else if (currentChar == '╬╡') {
                                                                        ^
    ```
    This was addressed by using the codepoint representation instead (`\u03b5`).

These changes allow the build to succeed on my system (JDK 8, Windows 10).